### PR TITLE
Fix newline loop when translation is empty

### DIFF
--- a/SubtitleTranslate - ChatGPT - Without Context.as
+++ b/SubtitleTranslate - ChatGPT - Without Context.as
@@ -422,7 +422,7 @@ string Translate(string Text, string &in SrcLang, string &in DstLang) {
         choices[0]["message"]["content"].isString()) {
         string translatedText = choices[0]["message"]["content"].asString();
         if (selected_model.find("gemini") != -1) {
-            while (translatedText.substr(translatedText.length() - 1, 1) == "\n") {
+            while (translatedText.length() > 0 && translatedText.substr(translatedText.length() - 1, 1) == "\n") {
                 translatedText = translatedText.substr(0, translatedText.length() - 1);
             }
         }

--- a/SubtitleTranslate - ChatGPT.as
+++ b/SubtitleTranslate - ChatGPT.as
@@ -446,7 +446,7 @@ string Translate(string Text, string &in SrcLang, string &in DstLang) {
         choices[0]["message"]["content"].isString()) {
         string translatedText = choices[0]["message"]["content"].asString();
         if (selected_model.find("gemini") != -1) {
-            while (translatedText.substr(translatedText.length() - 1, 1) == "\n") {
+            while (translatedText.length() > 0 && translatedText.substr(translatedText.length() - 1, 1) == "\n") {
                 translatedText = translatedText.substr(0, translatedText.length() - 1);
             }
         }


### PR DESCRIPTION
## Summary
- avoid out-of-bounds string access when trimming newlines

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_683f41911d60832cb16a4fb5ac4d4761