### PR TITLE
Fix repo name casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ One key advantage of using ChatGPT for subtitle translation is its ability to un
 
 - **Google Translate Result:**  
   > *"你要老了我他妈的宇宙吗?"*  
-  ![](https://github.com/Felix3322/PotPlayer_Chatgpt_Translate/blob/master/docs/Google%20translate.png)  
+  ![](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/blob/master/docs/Google%20translate.png)  
   _(Nonsensical and incorrect)_
 
 - **ChatGPT Translation Result:**  
   > *"你要像《老黄犬》一样对待我的宇宙?"*  
-  ![](https://github.com/Felix3322/PotPlayer_Chatgpt_Translate/blob/master/docs/ChatGPT.png)  
+  ![](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/blob/master/docs/ChatGPT.png)  
   _(Correctly captures the reference and intended meaning)_
 
 ## 🧐 ChatGPT Without Context vs. ChatGPT With Context Comparison
@@ -82,12 +82,12 @@ One key advantage of using ChatGPT for subtitle translation is its ability to un
 
 - **ChatGPT Translation (Without Context):**  
   > *"但是，在现实生活中成为一个人甚至更好。"*  
-  ![](https://github.com/Felix3322/PotPlayer_Chatgpt_Translate/blob/master/docs/without%20context.png)  
+  ![](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/blob/master/docs/without%20context.png)  
   _(Literal translation, failing to capture the implied meaning)_
 
 - **ChatGPT Translation (With Context):**  
   > *"但在现实生活中成为一个反派更好。"*  
-  ![](https://github.com/Felix3322/PotPlayer_Chatgpt_Translate/blob/master/docs/using%20context.png)  
+  ![](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/blob/master/docs/using%20context.png)  
   _(Accurately capturing the intended context)_
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
@@ -121,7 +121,7 @@ Click below to watch the tutorial on Bilibili:
 ### Fully Automatic Installation (Recommended) ⚡
 
 1. **Download the Installer:**  
-   [Installer](https://github.com/Felix3322/PotPlayer_Chatgpt_Translate/releases/latest)  
+   [Installer](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/releases/latest)  
    *(The installer is open source, so you can review the source code)*
 2. **Run the Installer:**  
    - Double-click `installer.exe` to start the installation.  
@@ -282,7 +282,7 @@ Personal website: [obanarchy.org](https://obanarchy.org)
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=felix3322/potplayer_chatgpt_translate&type=Date)](https://www.star-history.com/#felix3322/potplayer_chatgpt_translate&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=Felix3322/PotPlayer_ChatGPT_Translate&type=Date)](https://www.star-history.com/#Felix3322/PotPlayer_ChatGPT_Translate&Date)
 
 ---
 

--- a/docs/readme_zh-tw.md
+++ b/docs/readme_zh-tw.md
@@ -71,13 +71,13 @@
 * **Google 翻譯結果：**
 
   > *"你要老了我他媽的宇宙嗎？"*
-  > ![](https://github.com/Felix3322/PotPlayer_Chatgpt_Translate/blob/master/docs/Google%20translate.png)
+  > ![](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/blob/master/docs/Google%20translate.png)
   > *(意義不明且不正確)*
 
 * **ChatGPT 翻譯結果：**
 
   > *"你要像《老黃狗》一樣對待我的宇宙？"*
-  > ![](https://github.com/Felix3322/PotPlayer_Chatgpt_Translate/blob/master/docs/ChatGPT.png)
+  > ![](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/blob/master/docs/ChatGPT.png)
   > *(準確捕捉引用及其意圖)*
 
 ## 🧐 ChatGPT 無上下文 vs ChatGPT 有上下文
@@ -89,13 +89,13 @@
 * **ChatGPT 翻譯（無上下文）：**
 
   > *"但是，在現實生活中成為一個人甚至更好。"*
-  > ![](https://github.com/Felix3322/PotPlayer_Chatgpt_Translate/blob/master/docs/without%20context.png)
+  > ![](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/blob/master/docs/without%20context.png)
   > *(字面翻譯，未能體現隱含意義)*
 
 * **ChatGPT 翻譯（有上下文）：**
 
   > *"但在現實生活中成為反派更好。"*
-  > ![](https://github.com/Felix3322/PotPlayer_Chatgpt_Translate/blob/master/docs/using%20context.png)
+  > ![](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/blob/master/docs/using%20context.png)
   > *(準確捕捉語境)*
 
 <p align="right">(<a href="#readme-top">回到頂部</a>)</p>
@@ -129,7 +129,7 @@
 ### 全自動安裝（推薦） ⚡
 
 1. **下載安裝程式：**
-   [安裝程式](https://github.com/Felix3322/PotPlayer_Chatgpt_Translate/releases/latest)
+   [安裝程式](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/releases/latest)
    *(安裝程式為開源，可檢視其原始碼)*
 2. **執行安裝程式：**
 
@@ -301,7 +301,7 @@ Code LLaMA: code-llama-34b|https://api.llama.ai/v1/code/completions
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=felix3322/potplayer_chatgpt_translate\&type=Date)](https://www.star-history.com/#felix3322/potplayer_chatgpt_translate&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=Felix3322/PotPlayer_ChatGPT_Translate\&type=Date)](https://www.star-history.com/#Felix3322/PotPlayer_ChatGPT_Translate&Date)
 
 <!-- MARKDOWN LINKS & IMAGES -->
 

--- a/docs/readme_zh.md
+++ b/docs/readme_zh.md
@@ -67,12 +67,12 @@
 
 - **Google 翻译结果：**  
   > *"你要老了我他妈的宇宙吗?"*  
-  ![](https://github.com/Felix3322/PotPlayer_Chatgpt_Translate/blob/master/docs/Google%20translate.png)  
+  ![](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/blob/master/docs/Google%20translate.png)  
   _(意义不明且不正确)_
 
 - **ChatGPT 翻译结果：**  
   > *"你要像《老黄犬》一样对待我的宇宙?"*  
-  ![](https://github.com/Felix3322/PotPlayer_Chatgpt_Translate/blob/master/docs/ChatGPT.png)  
+  ![](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/blob/master/docs/ChatGPT.png)  
   _(准确捕捉了引用及其意图)_
 
 ##  🧐 ChatGPT 无上下文 vs ChatGPT 有上下文对比
@@ -82,12 +82,12 @@
 
 - **ChatGPT 翻译结果（无上下文）：**  
   > *"但是，在现实生活中成为一个人甚至更好。"*  
-  ![](https://github.com/Felix3322/PotPlayer_Chatgpt_Translate/blob/master/docs/without%20context.png)  
+  ![](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/blob/master/docs/without%20context.png)  
   _(字面翻译，未能体现隐含意义)_
 
 - **ChatGPT 翻译结果（有上下文）：**  
   > *"但在现实生活中成为一个反派更好。"*  
-  ![](https://github.com/Felix3322/PotPlayer_Chatgpt_Translate/blob/master/docs/using%20context.png)  
+  ![](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/blob/master/docs/using%20context.png)  
   _(准确捕捉语境)_
 
 <p align="right">(<a href="#readme-top">返回顶部</a>)</p>
@@ -121,7 +121,7 @@
 ### 全自动安装（推荐） ⚡
 
 1. **下载安装程序：**  
-   [安装程序](https://github.com/Felix3322/PotPlayer_Chatgpt_Translate/releases/latest)  
+   [安装程序](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/releases/latest)  
    *(安装程序是开源的，你可以查看其源码)*
 2. **运行安装程序：**  
    - 双击 installer.exe 启动安装。  
@@ -281,7 +281,7 @@ Code LLaMA: code-llama-34b|https://api.llama.ai/v1/code/completions
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=felix3322/potplayer_chatgpt_translate&type=Date)](https://www.star-history.com/#felix3322/potplayer_chatgpt_translate&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=Felix3322/PotPlayer_ChatGPT_Translate&type=Date)](https://www.star-history.com/#Felix3322/PotPlayer_ChatGPT_Translate&Date)
 
 <!-- MARKDOWN LINKS & IMAGES -->
 [stars-shield]: https://img.shields.io/github/stars/Felix3322/PotPlayer_ChatGPT_Translate.svg?style=for-the-badge

--- a/releases/build/installer.py
+++ b/releases/build/installer.py
@@ -40,7 +40,7 @@ LANGUAGE_STRINGS = {
         "install_progress": "Installation Progress:",
         "cancel": "Cancel",
         "finish": "Finish",
-        "author_info": "Author: Felix3322  |  Project: https://github.com/Felix3322/PotPlayer_Chatgpt_Translate",
+        "author_info": "Author: Felix3322  |  Project: https://github.com/Felix3322/PotPlayer_ChatGPT_Translate",
         "file_exists_3choice": "File {} already exists.\n\nPlease choose:\n- Overwrite & Upgrade\n- Rename\n- Cancel",
         "installation_cancelled": "Installation cancelled by user.",
         "custom_name_prompt": "Please enter the new file name:",
@@ -76,7 +76,7 @@ LANGUAGE_STRINGS = {
         "install_progress": "安装进度：",
         "cancel": "取消",
         "finish": "完成",
-        "author_info": "作者: Felix3322  |  项目: https://github.com/Felix3322/PotPlayer_Chatgpt_Translate",
+        "author_info": "作者: Felix3322  |  项目: https://github.com/Felix3322/PotPlayer_ChatGPT_Translate",
         "file_exists_3choice": "文件 {} 已存在。\n\n请选择：\n- 覆盖升级\n- 重命名\n- 取消",
         "installation_cancelled": "用户取消了安装。",
         "custom_name_prompt": "请输入新的文件名:",
@@ -415,7 +415,7 @@ class WelcomeFrame(tk.Frame):
         self.btn.pack(pady=20)
         self.author = tk.Label(self, text=controller.strings["author_info"], font=("Arial", 10), fg="blue", cursor="hand2")
         self.author.pack(side="bottom", pady=10)
-        self.author.bind("<Button-1>", lambda e: webbrowser.open("https://github.com/Felix3322/PotPlayer_Chatgpt_Translate"))
+        self.author.bind("<Button-1>", lambda e: webbrowser.open("https://github.com/Felix3322/PotPlayer_ChatGPT_Translate"))
     def on_show(self):
         s = self.controller.strings
         self.lbl.config(text=s["welcome_message"])


### PR DESCRIPTION
## Summary
- update README and docs with proper repository name casing
- fix project links in installer script

## Testing
- `python -m py_compile releases/build/installer.py`
- `python releases/build/installer.py --help` *(fails: No module named 'win32com')*

------
https://chatgpt.com/codex/tasks/task_e_683f43fe6c38832ca53e31d22e1ae3d3