### PR TITLE
提示词优化

### DIFF
--- a/SubtitleTranslate - ChatGPT.as
+++ b/SubtitleTranslate - ChatGPT.as
@@ -415,39 +415,26 @@ string Translate(string Text, string &in SrcLang, string &in DstLang) {
     }
 
     string systemMsg =
-        "You are a subtitle translation tool. "
-        "Your ONLY task is to translate the subtitle text explicitly given under 'Subtitle to translate:'. "
-        "NEVER translate or output the reference CONTEXT. "
-        "NEVER output the original text, quotes, explanations, or anything other than the translation. "
-        "If the input is already in the target language, output it directly, unchanged.";
+        "You are an expert subtitle translate tool with a deep understanding of both language and culture."
+        "Based on contextual clues, you provide translations that capture not only the literal meaning but also the nuanced metaphors, euphemisms, and cultural symbols embedded in the dialogue."
+        "Your translations reflect the intended tone and cultural context, ensuring that every subtle reference and idiomatic expression is accurately conveyed."
+        "I will provide you with some context for better translations, but DO NOT output any of them.\n"
+
+        "Rules:\n"
+        "1. Output the translation only."
+        "2. Do NOT output explanations, comments, or formatting."
+        "3. Do NOT use any special characters.";
 
     string userMsg =
-        "Translate ONLY the text under the section 'Subtitle to translate:'.\n"
-        "Do NOT include the section called '[CONTEXT]'.\n"
-        "The CONTEXT is for your understanding ONLY and must NEVER appear in your output.\n\n"
-
+        "Translate the content under the section 'Subtitle to translate' based on the section 'Subtitle context' if it exists.\n\n"
         "Source language: " + (SrcLang == "" ? "Auto Detect" : SrcLang) + "\n"
-        "Target language: " + DstLang + "\n\n"
-
-        // 正向约束
-        "Rules:\n"
-        "1. Output ONLY the translation of the subtitle.\n"
-        "2. Do NOT output the original subtitle.\n"
-        "3. Do NOT output the CONTEXT.\n"
-        "4. Do NOT output explanations, comments, or formatting.\n"
-
-        // 反向约束（黑名单）
-        "Forbidden outputs:\n"
-        "- Any text from CONTEXT.\n"
-        "- Any mention of 'context', 'subtitle', 'translation'.\n"
-        "- Quotes, brackets, or tags.\n"
-
-        "\nSubtitle to translate:\n" + Text;
+        "Target language: " + DstLang + "\n\n";
 
     if (context != "") {
-        userMsg += "\n\n[CONTEXT] (DO NOT TRANSLATE OR OUTPUT):\n" + context;
+        userMsg += "Subtitle context(DO NOT OUTPUT!):\n" + "{" + context + "}\n\n";
     }
 
+    userMsg += "Subtitle to translate:\n" + "{" + Text + "}";
 
     string escapedSystemMsg = JsonEscape(systemMsg);
     string escapedUserMsg = JsonEscape(userMsg);


### PR DESCRIPTION
基于Commit f1d4eeb 的提示词优化，在重新添加之前版本提示词的同时，解决了模型误解提示词的问题。并针对提示词的数量和结构进行调整，改善了使用付费API时的token消耗。

在提示词序列长度足够的情况下，通过将上下文内容前置，避免更新整个上下文内容，更充分地利用提示词缓存（在付费API中缓存命中时token价格通常更低）。同时也增加了上下文和待翻译内容之间的区分度，避免了误解提示词的问题，在本地部署的QWEN3-30B-A3B上测试，翻译结果更加稳定且消耗提示词更少。

<img width="1086" height="239" alt="image" src="https://github.com/user-attachments/assets/28bf81bb-5ad3-44d0-aa22-d68b600f80dd" />
注，图中的n_prompt_tokens是已缓存的上下文长度，在此次调用中仅需更新27tokens即可。