### PR TITLE
Add context cache installer wiring

### DIFF
--- a/SubtitleTranslate - ChatGPT - Without Context.as
+++ b/SubtitleTranslate - ChatGPT - Without Context.as
@@ -12,7 +12,7 @@ string GetTitle() {
 }
 
 string GetVersion() {
-    return "1.6-wc";
+    return "1.7-wc";
 }
 
 string GetDesc() {

--- a/SubtitleTranslate - ChatGPT.as
+++ b/SubtitleTranslate - ChatGPT.as
@@ -11,7 +11,7 @@ string GetTitle() {
 }
 
 string GetVersion() {
-    return "1.6";
+    return "1.7";
 }
 
 string GetDesc() {
@@ -28,19 +28,23 @@ string GetLoginTitle() {
 string GetLoginDesc() {
     return "{$CP949=모델 이름, API 주소, 선택적 nullkey, 지연(ms) 및 재시도 모드(0-3)를 입력하십시오 (예: gpt-5-nano|https://api.openai.com/v1/chat/completions|nullkey|500|retry1).$}"
          + "{$CP949=\n\n설치 프로그램에서 미리 구성한 값이 있다면 PotPlayer 패널에서 다시 설정하기 전까지 해당 값을 사용하며, 패널에서 설정하면 해당 설정이 항상 우선 적용됩니다.$}"
+         + "{$CP949=\n\n선택적으로 cache=auto 또는 cache=off 를 추가하여 문맥 캐시 모드를 제어할 수 있으며, auto 는 지원되지 않을 경우 chat 방식으로 자동 전환됩니다.$}"
          + "{$CP950=請輸入模型名稱、API 地址、可選的 nullkey、延遲毫秒與重試模式(0-3)（例如: gpt-5-nano|https://api.openai.com/v1/chat/completions|nullkey|500|retry1）。$}"
          + "{$CP950=\n\n如果安裝包已寫入預設配置，在 PotPlayer 面板中未重新設定之前會沿用這些配置；一旦在面板中調整，將始終以面板設定為準。$}"
+         + "{$CP950=\n\n可選加上 cache=auto 或 cache=off 以控制上下文快取模式，auto 會在不支援時自動回退至 chat。$}"
          + "{$CP936=请输入模型名称、API 地址、可选的 nullkey、延迟毫秒和重试模式(0-3)（例如: gpt-5-nano|https://api.openai.com/v1/chat/completions|nullkey|500|retry1）。$}"
          + "{$CP936=\n\n如果安装包已经写入默认配置，在 PotPlayer 面板中没有重新设置之前会继续使用这些配置；一旦在面板中修改，将始终以面板设置为准。$}"
+         + "{$CP936=\n\n可选追加 cache=auto 或 cache=off 用于控制上下文缓存模式，auto 在不支持时会自动回退到 chat。$}"
          + "{$CP0=Please enter the model name, API URL, optional 'nullkey', optional delay in ms, and retry mode 0-3 (e.g., gpt-5-nano|https://api.openai.com/v1/chat/completions|nullkey|500|retry1).$}"
-         + "{$CP0=\n\nInstaller defaults will remain in effect until you update the settings in PotPlayer's panel, and any panel changes will always take priority.$}";
+         + "{$CP0=\n\nInstaller defaults will remain in effect until you update the settings in PotPlayer's panel, and any panel changes will always take priority.$}"
+         + "{$CP0=\n\nOptionally append cache=auto or cache=off to control context caching. Auto falls back to chat when caching is unsupported.$}";
 }
 
 string GetUserText() {
-    return "{$CP949=모델 이름|API 주소|nullkey|지연(ms)|재시도 모드 (현재: " + selected_model + " | " + apiUrl + " | " + delay_ms + " | " + retry_mode + ")$}"
-         + "{$CP950=模型名稱|API 地址|nullkey|延遲ms|重試模式 (目前: " + selected_model + " | " + apiUrl + " | " + delay_ms + " | " + retry_mode + ")$}"
-         + "{$CP936=模型名称|API 地址|nullkey|延迟ms|重试模式 (目前: " + selected_model + " | " + apiUrl + " | " + delay_ms + " | " + retry_mode + ")$}"
-         + "{$CP0=Model Name|API URL|nullkey|Delay ms|Retry mode (Current: " + selected_model + " | " + apiUrl + " | " + delay_ms + " | " + retry_mode + ")$}";
+    return "{$CP949=모델 이름|API 주소|nullkey|지연(ms)|재시도 모드|캐시 모드 (현재: " + selected_model + " | " + apiUrl + " | " + delay_ms + " | " + retry_mode + " | " + context_cache_mode + ")$}"
+         + "{$CP950=模型名稱|API 地址|nullkey|延遲ms|重試模式|快取模式 (目前: " + selected_model + " | " + apiUrl + " | " + delay_ms + " | " + retry_mode + " | " + context_cache_mode + ")$}"
+         + "{$CP936=模型名称|API 地址|nullkey|延迟ms|重试模式|缓存模式 (目前: " + selected_model + " | " + apiUrl + " | " + delay_ms + " | " + retry_mode + " | " + context_cache_mode + ")$}"
+         + "{$CP0=Model Name|API URL|nullkey|Delay ms|Retry mode|Cache mode (Current: " + selected_model + " | " + apiUrl + " | " + delay_ms + " | " + retry_mode + " | " + context_cache_mode + ")$}";
 }
 
 string GetPasswordText() {
@@ -59,6 +63,7 @@ string pre_delay_ms = "0"; // will be replaced during installation
 string pre_retry_mode = "0"; // will be replaced during installation
 string pre_context_token_budget = "6000"; // approx. tokens reserved for context (0 = auto)
 string pre_context_truncation_mode = "drop_oldest"; // drop_oldest | smart_trim
+string pre_context_cache_mode = "auto"; // auto | off
 
 string api_key = pre_api_key;
 string selected_model = pre_selected_model; // Default model
@@ -67,8 +72,11 @@ string delay_ms = pre_delay_ms; // Request delay in ms
 string retry_mode = pre_retry_mode; // Auto retry mode
 string context_token_budget = pre_context_token_budget; // Approximate token budget for context
 string context_truncation_mode = pre_context_truncation_mode; // Truncation mode when context exceeds budget
+string context_cache_mode = pre_context_cache_mode; // auto | off
 string UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64)";
 array<string> subtitleHistory;  // Global subtitle history
+bool context_cache_disabled_for_session = false;
+string context_cache_disable_key = "";
 
 // Helper functions to load configuration while respecting installer defaults
 string BuildConfigSentinel(const string &in key) {
@@ -91,6 +99,7 @@ void RefreshConfiguration() {
     retry_mode = LoadInstallerConfig("gpt_retry_mode", pre_retry_mode);
     context_token_budget = LoadInstallerConfig("gpt_context_token_budget", pre_context_token_budget);
     context_truncation_mode = LoadInstallerConfig("gpt_context_truncation_mode", pre_context_truncation_mode);
+    context_cache_mode = NormalizeCacheMode(LoadInstallerConfig("gpt_context_cache_mode", pre_context_cache_mode));
 }
 
 // Supported Language List
@@ -253,6 +262,7 @@ bool EqualsIgnoreCase(const string &in a, const string &in b) {
 
 // API Key and API Base verification process
 string ServerLogin(string User, string Pass) {
+    RefreshConfiguration();
     string errorAccum = "";
     User = User.Trim();
     Pass = Pass.Trim();
@@ -270,17 +280,26 @@ string ServerLogin(string User, string Pass) {
     bool allowNullApiKey = (Pass == "");
     string delayToken = "";
     string retryToken = "";
+    string cacheToken = "";
+    string normalizedCacheMode = context_cache_mode;
     if (tokens.length() >= 1) {
         userModel = tokens[0];
     }
     for (int i = 1; i < int(tokens.length()); i++) {
         string t = tokens[i];
-        if (t == "nullkey")
+        string lowered = ToLower(t);
+        if (lowered == "nullkey")
             allowNullApiKey = true;
-        else if (t.substr(0,5) == "retry" && IsDigits(t.substr(5)))
+        else if (lowered.length() >= 5 && lowered.substr(0,5) == "retry" && IsDigits(t.substr(5)))
             retryToken = t.substr(5);
         else if (IsDigits(t))
             delayToken = t;
+        else if (lowered.length() >= 6 && lowered.substr(0,6) == "cache=")
+            cacheToken = lowered.substr(6);
+        else if (lowered == "cacheauto" || lowered == "cacheon" || lowered == "cache")
+            cacheToken = "auto";
+        else if (lowered == "cacheoff" || lowered == "nocache")
+            cacheToken = "off";
         else if (customApiUrl == "")
             customApiUrl = t;
     }
@@ -288,6 +307,10 @@ string ServerLogin(string User, string Pass) {
         retry_mode = retryToken;
     if (delayToken != "")
         delay_ms = delayToken;
+    if (cacheToken != "")
+        normalizedCacheMode = NormalizeCacheMode(cacheToken);
+    else
+        normalizedCacheMode = NormalizeCacheMode(normalizedCacheMode);
     if (userModel == "") {
         errorAccum += "Model name not entered. Please enter a valid model name.\n";
         return errorAccum;
@@ -318,20 +341,24 @@ string ServerLogin(string User, string Pass) {
     if (testResponse != "") {
         JsonReader testReader;
         JsonValue testRoot;
-        if (testReader.parse(testResponse, testRoot)) {
-            if (testRoot.isObject() && testRoot["choices"].isArray() && testRoot["choices"].size() > 0) {
-                selected_model = userModel;
-                api_key = Pass;
-                HostSaveString("gpt_api_key", api_key);
-                HostSaveString("gpt_selected_model", selected_model);
-                HostSaveString("gpt_apiUrl", apiUrlLocal);
-                HostSaveString("gpt_delay_ms", delay_ms);
-    HostSaveString("gpt_retry_mode", retry_mode);
-                return "200 ok";
-            } else {
-                if (testRoot.isObject() && testRoot["error"].isObject() && testRoot["error"]["message"].isString())
-                    errorAccum += "Test message error: " + testRoot["error"]["message"].asString() + "\n";
-                else
+            if (testReader.parse(testResponse, testRoot)) {
+                if (testRoot.isObject() && testRoot["choices"].isArray() && testRoot["choices"].size() > 0) {
+                    selected_model = userModel;
+                    api_key = Pass;
+                    HostSaveString("gpt_api_key", api_key);
+                    HostSaveString("gpt_selected_model", selected_model);
+                    HostSaveString("gpt_apiUrl", apiUrlLocal);
+                    HostSaveString("gpt_delay_ms", delay_ms);
+                    HostSaveString("gpt_retry_mode", retry_mode);
+                    context_cache_mode = normalizedCacheMode;
+                    HostSaveString("gpt_context_cache_mode", context_cache_mode);
+                    context_cache_disabled_for_session = false;
+                    context_cache_disable_key = "";
+                    return "200 ok";
+                } else {
+                    if (testRoot.isObject() && testRoot["error"].isObject() && testRoot["error"]["message"].isString())
+                        errorAccum += "Test message error: " + testRoot["error"]["message"].asString() + "\n";
+                    else
                     errorAccum += "Test message response invalid.\n";
             }
         } else {
@@ -355,7 +382,11 @@ string ServerLogin(string User, string Pass) {
                     HostSaveString("gpt_selected_model", selected_model);
                     HostSaveString("gpt_apiUrl", apiUrlLocal);
                     HostSaveString("gpt_delay_ms", delay_ms);
-    HostSaveString("gpt_retry_mode", retry_mode);
+                    HostSaveString("gpt_retry_mode", retry_mode);
+                    context_cache_mode = normalizedCacheMode;
+                    HostSaveString("gpt_context_cache_mode", context_cache_mode);
+                    context_cache_disabled_for_session = false;
+                    context_cache_disable_key = "";
                     return "Warning: Your API base was auto-corrected to: " + apiUrlLocal + "\n200 ok";
                 } else {
                     if (correctedRoot.isObject() && correctedRoot["error"].isObject() && correctedRoot["error"]["message"].isString())
@@ -425,6 +456,9 @@ void ServerLogout() {
     retry_mode = pre_retry_mode;
     context_token_budget = pre_context_token_budget;
     context_truncation_mode = pre_context_truncation_mode;
+    context_cache_mode = pre_context_cache_mode;
+    context_cache_disabled_for_session = false;
+    context_cache_disable_key = "";
     HostSaveString("gpt_api_key", "");
     HostSaveString("gpt_selected_model", selected_model);
     HostSaveString("gpt_apiUrl", apiUrl);
@@ -432,6 +466,7 @@ void ServerLogout() {
     HostSaveString("gpt_retry_mode", retry_mode);
     HostSaveString("gpt_context_token_budget", context_token_budget);
     HostSaveString("gpt_context_truncation_mode", context_truncation_mode);
+    HostSaveString("gpt_context_cache_mode", context_cache_mode);
     HostPrintUTF8("Successfully logged out.\n");
 }
 
@@ -728,16 +763,27 @@ string Translate(string Text, string &in SrcLang, string &in DstLang) {
         "2. Do NOT output extra comments or explanations."
         "3. Do NOT use any special characters or formatting in the translation.";
 
-    string userMsg =
-        "Translate the complete content under the section 'Subtitle to translate' based on the section 'Subtitle context', if it exists.\n\n"
-        "Source language: " + (SrcLang == "" ? "Auto Detect" : SrcLang) + "\n"
-        "Target language: " + DstLang + "\n\n";
+    string sourceLabel = (SrcLang == "" ? "Auto Detect" : SrcLang);
+    string targetLangCode = DstLang;
+    string targetLabel = targetLangCode;
 
+    string userInstruction =
+        "Translate the complete content under the section 'Subtitle to translate' based on the section 'Subtitle context', if it exists.\n\n"
+        "Source language: " + sourceLabel + "\n"
+        "Target language: " + targetLabel + "\n\n";
+
+    string userMsg = userInstruction;
     if (context != "") {
         userMsg += "[Subtitle context](DO NOT OUTPUT!):\n" + "{" + context + "}\n\n";
     }
-
     userMsg += "[Subtitle to translate]:\n" + "{" + Text + "}";
+
+    string cachingInstruction =
+        "Translate the complete content under 'Subtitle to translate' using the provided context entries if available. "
+        "Each entry is shown as \"Context entry (older to newer): {...}\" and must never appear in the output.\n\n"
+        "Source language: " + sourceLabel + "\n"
+        "Target language: " + targetLabel + "\n\n"
+        "Output only the translated subtitle without extra commentary.";
 
     string escapedSystemMsg = JsonEscape(systemMsg);
     string escapedUserMsg = JsonEscape(userMsg);
@@ -750,66 +796,82 @@ string Translate(string Text, string &in SrcLang, string &in DstLang) {
     string headers = "Authorization: Bearer " + api_key + "\nContent-Type: application/json";
     int delayInt = ParseInt(delay_ms);
     int retryModeInt = ParseInt(retry_mode);
-    string response = "";
-    int attempts = 0;
-    while (true) {
-        if (attempts == 0 || (retryModeInt == 3 && attempts > 0)) {
-            if (delayInt > 0)
-                HostSleep(delayInt);
+
+    string cacheSessionKey = context_cache_mode + "|" + apiUrl + "|" + selected_model;
+    if (cacheSessionKey != context_cache_disable_key)
+        context_cache_disabled_for_session = false;
+    context_cache_disable_key = cacheSessionKey;
+
+    string translation = "";
+    if (context_cache_mode != "off" && !context_cache_disabled_for_session) {
+        string responsesUrl = DeriveResponsesUrl(apiUrl);
+        string cacheFailure = "";
+        if (responsesUrl != "") {
+            translation = TranslateWithResponses(responsesUrl, headers, systemMsg, cachingInstruction, @contextSegments, Text, delayInt, retryModeInt, cacheFailure);
+        } else {
+            cacheFailure = "Unable to resolve responses endpoint from current API URL.";
         }
-        response = HostUrlGetString(apiUrl, UserAgent, headers, requestData);
-        if (response != "" || retryModeInt == 0 || (retryModeInt == 1 && attempts >= 1))
-            break;
-        attempts++;
-    }
-    if (response == "") {
-        HostPrintUTF8("Translation request failed. Please check network connection or API Key.\n");
-        return "";
-    }
-
-    JsonReader Reader;
-    JsonValue Root;
-    if (!Reader.parse(response, Root)) {
-        HostPrintUTF8("Failed to parse API response.\n");
-        return "";
-    }
-
-    JsonValue choices = Root["choices"];
-    if (choices.isArray() && choices.size() > 0 &&
-        choices[0].isObject() &&
-        choices[0]["message"].isObject() &&
-        choices[0]["message"]["content"].isString()) {
-        string translatedText = choices[0]["message"]["content"].asString();
-        if (selected_model.find("gemini") != -1) {
-            while (translatedText.length() > 0 && translatedText.substr(translatedText.length() - 1, 1) == "\n") {
-                translatedText = translatedText.substr(0, translatedText.length() - 1);
+        if (translation == "") {
+            if (!context_cache_disabled_for_session) {
+                context_cache_disabled_for_session = true;
+                string fallbackMessage = cacheFailure == "" ? "Context caching failed." : "Context caching failed: " + cacheFailure;
+                HostPrintUTF8(fallbackMessage + "\nUsing chat completions for this session.\n");
             }
         }
-        if (DstLang == "fa" || DstLang == "ar" || DstLang == "he") {
-            string UNICODE_RLE = "\u202B";
-            translatedText = UNICODE_RLE + translatedText;
-        }
-        SrcLang = "UTF8";
-        DstLang = "UTF8";
-        return translatedText.Trim();
     }
 
-    if (Root.isObject() &&
-        Root["error"].isObject() &&
-        Root["error"]["message"].isString()) {
-        string errorMessage = Root["error"]["message"].asString();
-        HostPrintUTF8("API Error: " + errorMessage + "\n");
-        return "API Error: " + errorMessage;
-    } else {
-        HostPrintUTF8("Translation failed. Please check input parameters or API Key configuration.\n");
-        return "Translation failed. Please check input parameters or API Key configuration.";
+    if (translation == "") {
+        string response = ExecuteWithRetry(apiUrl, headers, requestData, delayInt, retryModeInt);
+        if (response == "") {
+            HostPrintUTF8("Translation request failed. Please check network connection or API Key.\n");
+            return "";
+        }
+
+        JsonReader Reader;
+        JsonValue Root;
+        if (!Reader.parse(response, Root)) {
+            HostPrintUTF8("Failed to parse API response.\n");
+            return "";
+        }
+
+        JsonValue choices = Root["choices"];
+        if (choices.isArray() && choices.size() > 0 &&
+            choices[0].isObject() &&
+            choices[0]["message"].isObject() &&
+            choices[0]["message"]["content"].isString()) {
+            translation = choices[0]["message"]["content"].asString();
+        } else if (Root.isObject() &&
+                   Root["error"].isObject() &&
+                   Root["error"]["message"].isString()) {
+            string errorMessage = Root["error"]["message"].asString();
+            HostPrintUTF8("API Error: " + errorMessage + "\n");
+            return "API Error: " + errorMessage;
+        } else {
+            HostPrintUTF8("Translation failed. Please check input parameters or API Key configuration.\n");
+            return "Translation failed. Please check input parameters or API Key configuration.";
+        }
     }
+
+    if (selected_model.find("gemini") != -1) {
+        while (translation.length() > 0 && translation.substr(translation.length() - 1, 1) == "\n") {
+            translation = translation.substr(0, translation.length() - 1);
+        }
+    }
+    if (targetLangCode == "fa" || targetLangCode == "ar" || targetLangCode == "he") {
+        string UNICODE_RLE = "\u202B";
+        translation = UNICODE_RLE + translation;
+    }
+    SrcLang = "UTF8";
+    DstLang = "UTF8";
+    return translation.Trim();
 }
 
 // Plugin Initialization
 void OnInitialize() {
     HostPrintUTF8("ChatGPT translation plugin loaded.\n");
     RefreshConfiguration();
+    context_cache_disabled_for_session = false;
+    context_cache_disable_key = "";
     if (api_key != "") {
         HostPrintUTF8("Saved API Key, model name, and API URL loaded.\n");
     }
@@ -818,4 +880,127 @@ void OnInitialize() {
 // Plugin Finalization
 void OnFinalize() {
     HostPrintUTF8("ChatGPT translation plugin unloaded.\n");
+}
+string ToLower(const string &in s) {
+    string res = s;
+    for (uint i = 0; i < res.length(); i++) {
+        uint8 c = res[i];
+        if (c >= 65 && c <= 90)
+            res.setCharAt(i, c + 32);
+    }
+    return res;
+}
+
+string NormalizeCacheMode(const string &in mode) {
+    string trimmed = mode.Trim();
+    if (trimmed == "")
+        return "auto";
+    string lower = ToLower(trimmed);
+    if (lower == "off" || lower == "disable" || lower == "disabled" || lower == "chat")
+        return "off";
+    return "auto";
+}
+
+string DeriveResponsesUrl(const string &in originalUrl) {
+    string url = originalUrl.Trim();
+    while (url.length() > 0 && url.substr(url.length() - 1, 1) == "/")
+        url = url.substr(0, url.length() - 1);
+    if (url == "")
+        return "";
+    if (url.find("/responses") != -1)
+        return url;
+    int chatPos = url.find("/chat/completions");
+    if (chatPos != -1)
+        return url.substr(0, chatPos) + "/responses";
+    return url + "/responses";
+}
+
+string ExecuteWithRetry(const string &in url, const string &in headers, const string &in payload, int delayInt, int retryModeInt) {
+    string response = "";
+    int attempts = 0;
+    while (true) {
+        if (attempts == 0 || (retryModeInt == 3 && attempts > 0)) {
+            if (delayInt > 0)
+                HostSleep(delayInt);
+        }
+        response = HostUrlGetString(url, UserAgent, headers, payload);
+        if (response != "" || retryModeInt == 0 || (retryModeInt == 1 && attempts >= 1))
+            break;
+        attempts++;
+    }
+    return response;
+}
+
+string BuildResponsesPayload(const string &in systemMsg, const string &in instruction, const array<string>@ contextSegments, const string &in subtitleText) {
+    string escapedSystem = JsonEscape(systemMsg);
+    string escapedInstruction = JsonEscape(instruction);
+    string payload = "{\"model\":\"" + selected_model + "\",\"input\":[";
+    payload += "{\"role\":\"system\",\"content\":[{\"type\":\"input_text\",\"text\":\"" + escapedSystem + "\",\"cache_control\":{\"type\":\"ephemeral\"}}]}";
+    payload += ",{\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"" + escapedInstruction + "\",\"cache_control\":{\"type\":\"ephemeral\"}}";
+    if (contextSegments !is null && contextSegments.length() > 0) {
+        for (uint i = 0; i < contextSegments.length(); i++) {
+            string ctxLine = "Context entry (older to newer): {" + contextSegments[i] + "}";
+            string escapedCtxLine = JsonEscape(ctxLine);
+            payload += ",{\"type\":\"input_text\",\"text\":\"" + escapedCtxLine + "\",\"cache_control\":{\"type\":\"ephemeral\"}}";
+        }
+    }
+    string subtitleLine = "Subtitle to translate: {" + subtitleText + "}";
+    string escapedSubtitle = JsonEscape(subtitleLine);
+    payload += ",{\"type\":\"input_text\",\"text\":\"" + escapedSubtitle + "\"}]}";
+    payload += "],\"max_output_tokens\":1000,\"temperature\":0}";
+    return payload;
+}
+
+string ExtractResponsesText(JsonValue &in root) {
+    JsonValue output = root["output"];
+    if (output.isArray()) {
+        int size = output.size();
+        for (int i = 0; i < size; i++) {
+            JsonValue entry = output[i];
+            if (!entry.isObject())
+                continue;
+            JsonValue content = entry["content"];
+            if (!content.isArray())
+                continue;
+            int csize = content.size();
+            for (int j = 0; j < csize; j++) {
+                JsonValue part = content[j];
+                if (part.isObject()) {
+                    if (part["type"].isString() && part["type"].asString() == "output_text" && part["text"].isString())
+                        return part["text"].asString();
+                } else if (part.isString()) {
+                    return part.asString();
+                }
+            }
+        }
+    }
+    return "";
+}
+
+string TranslateWithResponses(const string &in responsesUrl, const string &in headers, const string &in systemMsg, const string &in instruction, const array<string>@ contextSegments, const string &in subtitleText, int delayInt, int retryModeInt, string &out failureReason) {
+    string requestData = BuildResponsesPayload(systemMsg, instruction, contextSegments, subtitleText);
+    string response = ExecuteWithRetry(responsesUrl, headers, requestData, delayInt, retryModeInt);
+    if (response == "") {
+        failureReason = "No response from Responses endpoint.";
+        return "";
+    }
+
+    JsonReader reader;
+    JsonValue root;
+    if (!reader.parse(response, root)) {
+        failureReason = "Failed to parse Responses API response.";
+        return "";
+    }
+
+    string translatedText = ExtractResponsesText(root);
+    if (translatedText != "") {
+        return translatedText;
+    }
+
+    if (root.isObject() && root["error"].isObject() && root["error"]["message"].isString()) {
+        failureReason = root["error"]["message"].asString();
+    } else {
+        failureReason = "Responses API returned no usable output.";
+    }
+    return "";
 }


### PR DESCRIPTION
## Summary
- extend the context-aware plugin to surface context cache configuration, update preconfigured defaults, and keep cache state in sync across login flows
- update the installer wizard to capture a context cache mode, persist it via apply_preconfig, and pass the value through the install thread
- bump the no-context plugin variant to version 1.7-wc to align with the main plugin release

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cc3075ee8c832c9137d23d40b53e39