### PR TITLE
Fix warnings and lowercase helper

### DIFF
--- a/SubtitleTranslate - ChatGPT.as
+++ b/SubtitleTranslate - ChatGPT.as
@@ -639,8 +639,10 @@ string Translate(string Text, string &in SrcLang, string &in DstLang) {
         shrinkTarget = historyTarget / 2;
     if (shrinkTarget < 32)
         shrinkTarget = 32;
-    if (subtitleHistory.length() > historyTarget) {
-        while (subtitleHistory.length() > shrinkTarget) {
+    const uint historyTargetCount = historyTarget > 0 ? uint(historyTarget) : 0;
+    const uint shrinkTargetCount = shrinkTarget > 0 ? uint(shrinkTarget) : 0;
+    if (subtitleHistory.length() > historyTargetCount) {
+        while (subtitleHistory.length() > shrinkTargetCount) {
             subtitleHistory.removeAt(0);
         }
     }
@@ -775,13 +777,7 @@ void OnFinalize() {
     HostPrintUTF8("ChatGPT translation plugin unloaded.\n");
 }
 string ToLower(const string &in s) {
-    string res = s;
-    for (uint i = 0; i < res.length(); i++) {
-        uint8 c = res[i];
-        if (c >= 65 && c <= 90)
-            res.setCharAt(i, c + 32);
-    }
-    return res;
+    return s.MakeLower();
 }
 
 string NormalizeCacheMode(const string &in mode) {


### PR DESCRIPTION
## Summary
- cast history management thresholds to unsigned values before comparing with subtitle history length
- replace custom lowercase conversion with built-in string MakeLower helper to avoid missing API usage

## Testing
- not run (script-only change)


------
https://chatgpt.com/codex/tasks/task_e_68da02811d14832cabb34492d8faee69