### PR TITLE
Adjust default temperature to comply with API requirements

### DIFF
--- a/SubtitleTranslate - ChatGPT - Without Context.as
+++ b/SubtitleTranslate - ChatGPT - Without Context.as
@@ -318,7 +318,7 @@ string ServerLogin(string User, string Pass) {
     string testRequestData = "{\"model\":\"" + userModel + "\"," 
                              "\"messages\":[{\"role\":\"system\",\"content\":\"" + escapedTestSystemMsg + "\"}," 
                              "{\"role\":\"user\",\"content\":\"" + escapedTestUserMsg + "\"}]," 
-                             "\"max_completion_tokens\":1,\"temperature\":0}"; 
+                             "\"max_completion_tokens\":1,\"temperature\":1}";
     string testResponse = HostUrlGetString(apiUrlLocal, UserAgent, verifyHeaders, testRequestData);
     if (testResponse != "") {
         JsonReader testReader;
@@ -559,7 +559,7 @@ string Translate(string Text, string &in SrcLang, string &in DstLang) {
     string requestData = "{\"model\":\"" + selected_model + "\"," 
                          "\"messages\":[{\"role\":\"system\",\"content\":\"" + escapedSystemMsg + "\"}," 
                          "{\"role\":\"user\",\"content\":\"" + escapedUserMsg + "\"}]," 
-                         "\"max_completion_tokens\":1000,\"temperature\":0}"; 
+                         "\"max_completion_tokens\":1000,\"temperature\":1}";
 
     string headers = "Authorization: Bearer " + api_key + "\nContent-Type: application/json";
     int delayInt = ParseInt(delay_ms);

--- a/SubtitleTranslate - ChatGPT.as
+++ b/SubtitleTranslate - ChatGPT.as
@@ -366,7 +366,7 @@ string ServerLogin(string User, string Pass) {
     string testRequestData = "{\"model\":\"" + userModel + "\"," 
                              "\"messages\":[{\"role\":\"system\",\"content\":\"" + escapedTestSystemMsg + "\"}," 
                              "{\"role\":\"user\",\"content\":\"" + escapedTestUserMsg + "\"}]," 
-                             "\"max_completion_tokens\":1,\"temperature\":0}"; 
+                             "\"max_completion_tokens\":1,\"temperature\":1}";
     string testResponse = HostUrlGetString(apiUrlLocal, UserAgent, verifyHeaders, testRequestData);
     if (testResponse != "") {
         JsonReader testReader;
@@ -686,7 +686,7 @@ string Translate(string Text, string &in SrcLang, string &in DstLang) {
     string requestData = "{\"model\":\"" + selected_model + "\"," 
                          "\"messages\":[{\"role\":\"system\",\"content\":\"" + escapedSystemMsg + "\"}," 
                          "{\"role\":\"user\",\"content\":\"" + escapedUserMsg + "\"}]," 
-                         "\"max_completion_tokens\":1000,\"temperature\":0}"; 
+                         "\"max_completion_tokens\":1000,\"temperature\":1}";
 
     string headers = "Authorization: Bearer " + api_key + "\nContent-Type: application/json";
     int delayInt = ParseInt(delay_ms);
@@ -888,7 +888,7 @@ string BuildResponsesPayload(const string &in systemMsg, const string &in instru
     string subtitleLine = "Subtitle to translate: {" + subtitleText + "}";
     string escapedSubtitle = JsonEscape(subtitleLine);
     payload += ",{\"type\":\"input_text\",\"text\":\"" + escapedSubtitle + "\"}]}";
-    payload += "],\"max_output_tokens\":1000,\"temperature\":0}";
+    payload += "],\"max_output_tokens\":1000,\"temperature\":1}";
     return payload;
 }
 


### PR DESCRIPTION
## Summary
- update the API verification payloads to use the supported default temperature value
- align translation and responses requests with the same temperature setting for compatibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da057cb0f8832c997881acf0223da1