### PR TITLE
Remove temperature and max_output_tokens from requests

### DIFF
--- a/SubtitleTranslate - ChatGPT - Without Context.as
+++ b/SubtitleTranslate - ChatGPT - Without Context.as
@@ -318,7 +318,7 @@ string ServerLogin(string User, string Pass) {
     string testRequestData = "{\"model\":\"" + userModel + "\"," 
                              "\"messages\":[{\"role\":\"system\",\"content\":\"" + escapedTestSystemMsg + "\"}," 
                              "{\"role\":\"user\",\"content\":\"" + escapedTestUserMsg + "\"}]," 
-                             "\"max_completion_tokens\":1,\"temperature\":1}";
+                             "\"max_completion_tokens\":1}";
     string testResponse = HostUrlGetString(apiUrlLocal, UserAgent, verifyHeaders, testRequestData);
     if (testResponse != "") {
         JsonReader testReader;
@@ -559,7 +559,7 @@ string Translate(string Text, string &in SrcLang, string &in DstLang) {
     string requestData = "{\"model\":\"" + selected_model + "\"," 
                          "\"messages\":[{\"role\":\"system\",\"content\":\"" + escapedSystemMsg + "\"}," 
                          "{\"role\":\"user\",\"content\":\"" + escapedUserMsg + "\"}]," 
-                         "\"max_completion_tokens\":1000,\"temperature\":1}";
+                         "\"max_completion_tokens\":1000}";
 
     string headers = "Authorization: Bearer " + api_key + "\nContent-Type: application/json";
     int delayInt = ParseInt(delay_ms);

--- a/SubtitleTranslate - ChatGPT.as
+++ b/SubtitleTranslate - ChatGPT.as
@@ -366,7 +366,7 @@ string ServerLogin(string User, string Pass) {
     string testRequestData = "{\"model\":\"" + userModel + "\"," 
                              "\"messages\":[{\"role\":\"system\",\"content\":\"" + escapedTestSystemMsg + "\"}," 
                              "{\"role\":\"user\",\"content\":\"" + escapedTestUserMsg + "\"}]," 
-                             "\"max_completion_tokens\":1,\"temperature\":1}";
+                             "\"max_completion_tokens\":1}";
     string testResponse = HostUrlGetString(apiUrlLocal, UserAgent, verifyHeaders, testRequestData);
     if (testResponse != "") {
         JsonReader testReader;
@@ -686,7 +686,7 @@ string Translate(string Text, string &in SrcLang, string &in DstLang) {
     string requestData = "{\"model\":\"" + selected_model + "\"," 
                          "\"messages\":[{\"role\":\"system\",\"content\":\"" + escapedSystemMsg + "\"}," 
                          "{\"role\":\"user\",\"content\":\"" + escapedUserMsg + "\"}]," 
-                         "\"max_completion_tokens\":1000,\"temperature\":1}";
+                         "\"max_completion_tokens\":1000}";
 
     string headers = "Authorization: Bearer " + api_key + "\nContent-Type: application/json";
     int delayInt = ParseInt(delay_ms);
@@ -888,7 +888,7 @@ string BuildResponsesPayload(const string &in systemMsg, const string &in instru
     string subtitleLine = "Subtitle to translate: {" + subtitleText + "}";
     string escapedSubtitle = JsonEscape(subtitleLine);
     payload += ",{\"type\":\"input_text\",\"text\":\"" + escapedSubtitle + "\"}]}";
-    payload += "],\"max_output_tokens\":1000,\"temperature\":1}";
+    payload += "]}";
     return payload;
 }
 


### PR DESCRIPTION
## Summary
- remove the temperature parameter from login and translation requests
- drop the max_output_tokens field from the responses payload to match the updated API requirements

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da06cf974c832cbf6c9dd9ec4f7a10