### PR TITLE
Update installer steps in README and Chinese docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,11 @@ Click below to watch the tutorial on Bilibili:
    *(The installer is open source, so you can review the source code)*
 2. **Run the Installer:**
    - Double-click `installer.exe` to start the installation.
-   - The PyQt6 wizard provides a modern, multi-language interface and automatically detects your PotPlayer path.
-   - You can verify or preconfigure your API model, URL and key, or simply skip this step; the wizard will try to auto-correct common mistakes.
-   - The optional `installer_qt.py` script from v1.5.2 can skip configuration when an existing installation is detected.
+   - Grant administrator privileges when prompted.
+   - The PyQt6 wizard auto-detects your PotPlayer `Extension\Subtitle\Translate` folder; confirm the path if you customized the install location.
+   - Choose the plugin variant (with context or without context).
+   - Configure the model, API endpoint, and API key (leave the key blank for endpoints that support `nullkey`).
+   - The installer can register an uninstaller entry to cleanly remove the plugin later.
    - Installer-provided defaults remain active until you update the plugin inside PotPlayer; any settings changed in the panel will always take priority over the installer values.
 
 ### Manual Installation 🔧
@@ -193,6 +195,21 @@ Click below to watch the tutorial on Bilibili:
      > ```
      > qwen2.5:7b|http://127.0.0.1:11434/v1/chat/completions|nullkey
      > ```
+     >
+     > **Optional tuning parameters (v1.7+):**  
+     > Append extra tokens separated by `|`:  
+     > - `delay_ms` (digits only): add a delay before each request  
+     > - `retryN` (N = 0–3): retry mode  
+     >   - `retry0`: no retry  
+     >   - `retry1`: one extra attempt on empty response  
+     >   - `retry2`: keep retrying until a response (no delay)  
+     >   - `retry3`: keep retrying, with delay before every attempt  
+     > - `cache=auto` / `cache=off`: context cache mode (context version only; auto falls back to chat if unsupported)  
+     >
+     > Example with all options:  
+     > ```
+     > gpt-4.1-nano|https://api.openai.com/v1/chat/completions|nullkey|500|retry1|cache=auto
+     > ```
 
    - **API Key:**  
      Enter your API key if needed.  
@@ -207,7 +224,7 @@ Click below to watch the tutorial on Bilibili:
 
 Use the format:  
 ```
-ModelName|API Base URL|nullkey (optional)
+ModelName|API Base URL|nullkey (optional)|delay_ms (optional)|retryN (optional)|cache=auto/off (optional)
 ```
 
 Here is a list of supported models:

--- a/docs/readme_zh-tw.md
+++ b/docs/readme_zh-tw.md
@@ -134,8 +134,11 @@
 2. **執行安裝程式：**
 
    * 雙擊 installer.exe 開始安裝。
-   * 安裝程式會自動偵測你的 PotPlayer 路徑並完成設定。
-   * 你可以選擇驗證模型、API 地址及 API Key，也可以跳過此步驟，安裝程式會嘗試自動修正常見錯誤。
+   * 若出現提示，請授權系統管理員權限。
+   * 安裝程式會自動偵測 PotPlayer 的 `Extension\Subtitle\Translate` 目錄，若有自訂路徑請確認或手動選擇。
+   * 選擇插件版本（有語境 / 無語境）。
+   * 設定模型、API 位址與 API Key（若介面不需要 API Key，可留空以使用 `nullkey`）。
+   * 安裝程式可選擇註冊解除安裝項目，方便之後移除插件。
    * 如果安裝程式已寫入預設配置，在你未於 PotPlayer 面板重新調整之前會沿用這些配置；一旦在面板中修改，將始終以面板設定為準。
 
 ### 手動安裝 🔧
@@ -202,6 +205,21 @@
      > ```
      > qwen2.5:7b|http://127.0.0.1:11434/v1/chat/completions|nullkey
      > ```
+     >
+     > **可選參數（v1.7+）：**
+     > 使用 `|` 追加：
+     > - `delay_ms`（純數字）：每次請求前等待的毫秒數
+     > - `retryN`（N = 0–3）：重試模式
+     >   - `retry0`：不重試
+     >   - `retry1`：空回應時再嘗試一次
+     >   - `retry2`：持續重試直到有回應（無延遲）
+     >   - `retry3`：持續重試且每次都等待延遲
+     > - `cache=auto` / `cache=off`：語境快取模式（僅語境版本適用；auto 不支援時會自動回退到 chat）
+     >
+     > 完整範例：
+     > ```
+     > gpt-4.1-nano|https://api.openai.com/v1/chat/completions|nullkey|500|retry1|cache=auto
+     > ```
 
    * **API Key：**
      輸入你的 API Key。
@@ -218,7 +236,7 @@
 格式如下：
 
 ```
-模型名稱|API 位址|nullkey（可選）
+模型名稱|API 位址|nullkey（可選）|delay_ms（可選）|retryN（可選）|cache=auto/off（可選）
 ```
 
 以下為已支援或可用的模型介面範例：

--- a/docs/readme_zh.md
+++ b/docs/readme_zh.md
@@ -125,8 +125,11 @@
    *(安装程序是开源的，你可以查看其源码)*
 2. **运行安装程序：**
    - 双击 installer.exe 启动安装。
-   - 安装程序会自动检测你的 PotPlayer 安装路径并完成安装设置。
-   - 你可以选择验证模型、API 地址和 API Key，也可以跳过此步骤，安装器会尝试自动纠正常见配置错误。
+   - 如有提示，请授予管理员权限。
+   - 安装程序会自动检测 PotPlayer 的 `Extension\Subtitle\Translate` 目录，如有自定义路径请确认或手动选择。
+   - 选择插件版本（有上下文 / 无上下文）。
+   - 配置模型、API 地址与 API Key（若接口无需 API Key，可留空以使用 `nullkey`）。
+   - 安装程序可选择注册卸载项，方便后续清理插件。
    - 如果安装器已经写入默认配置，在你未在 PotPlayer 面板中重新调整之前会继续使用这些配置；一旦在面板中修改，将始终以面板设置为准。
 
 ### 手动安装 🔧
@@ -185,6 +188,21 @@
      > ```
      > qwen2.5:7b|http://127.0.0.1:11434/v1/chat/completions|nullkey
      > ```
+     >
+     > **可选参数（v1.7+）：**  
+     > 通过 `|` 追加：  
+     > - `delay_ms`（纯数字）：每次请求前等待的毫秒数  
+     > - `retryN`（N = 0–3）：重试模式  
+     >   - `retry0`：不重试  
+     >   - `retry1`：空响应时再尝试一次  
+     >   - `retry2`：持续重试直到有响应（无延迟）  
+     >   - `retry3`：持续重试且每次都等待延迟  
+     > - `cache=auto` / `cache=off`：上下文缓存模式（仅上下文版本适用；auto 不支持时自动回退到 chat）  
+     >
+     > 完整示例：  
+     > ```
+     > gpt-4.1-nano|https://api.openai.com/v1/chat/completions|nullkey|500|retry1|cache=auto
+     > ```
 
    - **API Key：**  
      输入你的 API Key。  
@@ -199,7 +217,7 @@
 
 使用格式如下：  
 ```
-模型名称|API 地址|nullkey（可选）
+模型名称|API 地址|nullkey（可选）|delay_ms（可选）|retryN（可选）|cache=auto/off（可选）
 ```
 
 以下是已支持或可用的模型接口示例：


### PR DESCRIPTION
### Motivation
- The bundled installer flow changed and the documentation must reflect the latest wizard behavior and options (present in `releases/latest/installer.exe`).
- Users need clearer installer instructions for the auto-detected install path `Extension\Subtitle\Translate`, admin prompt, variant selection, and uninstaller registration.
- The plugin supports optional tuning parameters in v1.7+, so the model-format line must include `delay_ms`, `retryN`, and `cache=auto/off` for accurate configuration guidance.
- Keep English, Simplified Chinese and Traditional Chinese documentation consistent with the installer and plugin capabilities.

### Description
- Updated `README.md` to clarify installer steps including granting admin privileges, confirming the auto-detected `Extension\Subtitle\Translate` folder, variant selection, API endpoint/key configuration (including `nullkey`), and uninstaller registration. 
- Added an "Optional tuning parameters (v1.7+)" note and expanded the model-format to `ModelName|API Base URL|nullkey (optional)|delay_ms (optional)|retryN (optional)|cache=auto/off (optional)` in `README.md`.
- Mirrored the installer step updates and the expanded model-format line in `docs/readme_zh.md` and `docs/readme_zh-tw.md` to maintain parity across locales.
- Committed the documentation updates to the repository (files changed: `README.md`, `docs/readme_zh.md`, `docs/readme_zh-tw.md`).

### Testing
- No automated tests were run because these are documentation-only changes. 
- A local commit containing the changes was created successfully. 
- Repository searches and file inspections were used to verify the updated installer lines (no runtime validation required). 
- Spelling and formatting were validated by visual inspection in the edited files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69654d278f54832cbec10584a659ae3d)