### PR TITLE
Move installation sections to the top of each README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@
 <div>
   <h2>📑 Table of Contents</h2>
   <ol>
-    <li><a href="#about-the-project-">About The Project</a></li>
-    <li><a href="#video-tutorial-">Video Tutorial</a></li>
-    <li><a href="#built-with-">Built With</a></li>
     <li>
       <a href="#installation-">Installation</a>
       <ol>
@@ -47,6 +44,9 @@
         <li><a href="#manual-installation-">Manual Installation</a></li>
       </ol>
     </li>
+    <li><a href="#about-the-project-">About The Project</a></li>
+    <li><a href="#video-tutorial-">Video Tutorial</a></li>
+    <li><a href="#built-with-">Built With</a></li>
     <li><a href="#configuration-">Configuration</a></li>
     <li><a href="#usage-">Usage</a></li>
     <li><a href="#roadmap-">Roadmap</a></li>
@@ -56,6 +56,42 @@
     <li><a href="#acknowledgments-">Acknowledgments</a></li>
   </ol>
 </div>
+
+---
+
+## Installation 📦
+
+### Fully Automatic Installation (Recommended) ⚡
+
+1. **Download the Installer:**  
+   [Installer](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/releases/latest)  
+   *(The installer is open source, so you can review the source code)*
+2. **Run the Installer:**
+   - Double-click `installer.exe` to start the installation.
+   - Grant administrator privileges when prompted.
+   - The PyQt6 wizard auto-detects your PotPlayer `Extension\Subtitle\Translate` folder; confirm the path if you customized the install location.
+   - Choose the plugin variant (with context or without context).
+   - Configure the model, API endpoint, and API key (leave the key blank for endpoints that support `nullkey`).
+   - The installer can register an uninstaller entry to cleanly remove the plugin later.
+   - Installer-provided defaults remain active until you update the plugin inside PotPlayer; any settings changed in the panel will always take priority over the installer values.
+
+### Manual Installation 🔧
+
+1. **Download the ZIP File:**  
+   Download the latest ZIP file from this repository.
+2. **Extract the ZIP File:**  
+   Extract the contents to a temporary folder.
+3. **Copy Files:**  
+   Copy `ChatGPTSubtitleTranslate.as` and `ChatGPTSubtitleTranslate.ico` to the following directory:
+   ```
+   C:\Program Files\DAUM\PotPlayer\Extension\Subtitle\Translate
+   ```
+   Replace `C:\Program Files\DAUM\PotPlayer` with your custom PotPlayer installation path if necessary.
+
+> ℹ️ **If you switch between the context-aware and no-context scripts, replace both `.as` files together.**
+> Older copies that used the shared `FormatFailureTranslation` name can cause PotPlayer to report a conflict on whichever script loads first (often the standard context version). The current files use uniquely prefixed helpers to avoid this.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ---
 
@@ -117,42 +153,6 @@ Click below to watch the tutorial on Bilibili:
 - **AngleScript** – The scripting language used to develop the plugin  
 - **ChatGPT API** – Provides context-aware translation capabilities  
 - **PotPlayer API** – Enables seamless integration with PotPlayer
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
----
-
-## Installation 📦
-
-### Fully Automatic Installation (Recommended) ⚡
-
-1. **Download the Installer:**  
-   [Installer](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/releases/latest)  
-   *(The installer is open source, so you can review the source code)*
-2. **Run the Installer:**
-   - Double-click `installer.exe` to start the installation.
-   - Grant administrator privileges when prompted.
-   - The PyQt6 wizard auto-detects your PotPlayer `Extension\Subtitle\Translate` folder; confirm the path if you customized the install location.
-   - Choose the plugin variant (with context or without context).
-   - Configure the model, API endpoint, and API key (leave the key blank for endpoints that support `nullkey`).
-   - The installer can register an uninstaller entry to cleanly remove the plugin later.
-   - Installer-provided defaults remain active until you update the plugin inside PotPlayer; any settings changed in the panel will always take priority over the installer values.
-
-### Manual Installation 🔧
-
-1. **Download the ZIP File:**  
-   Download the latest ZIP file from this repository.
-2. **Extract the ZIP File:**  
-   Extract the contents to a temporary folder.
-3. **Copy Files:**  
-   Copy `ChatGPTSubtitleTranslate.as` and `ChatGPTSubtitleTranslate.ico` to the following directory:
-   ```
-   C:\Program Files\DAUM\PotPlayer\Extension\Subtitle\Translate
-   ```
-   Replace `C:\Program Files\DAUM\PotPlayer` with your custom PotPlayer installation path if necessary.
-
-> ℹ️ **If you switch between the context-aware and no-context scripts, replace both `.as` files together.**
-> Older copies that used the shared `FormatFailureTranslation` name can cause PotPlayer to report a conflict on whichever script loads first (often the standard context version). The current files use uniquely prefixed helpers to avoid this.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/docs/readme_zh-tw.md
+++ b/docs/readme_zh-tw.md
@@ -32,9 +32,6 @@
 <div>
   <h2>📑 目錄</h2>
   <ol>
-    <li><a href="#關於本專案-">關於本專案</a></li>
-    <li><a href="#影片教學-">影片教學</a></li>
-    <li><a href="#技術棧-">技術棧</a></li>
     <li>
       <a href="#安裝-">安裝</a>
       <ol>
@@ -42,6 +39,9 @@
         <li><a href="#手動安裝-">手動安裝</a></li>
       </ol>
     </li>
+    <li><a href="#關於本專案-">關於本專案</a></li>
+    <li><a href="#影片教學-">影片教學</a></li>
+    <li><a href="#技術棧-">技術棧</a></li>
     <li><a href="#配置-">配置</a></li>
     <li><a href="#使用方法-">使用方法</a></li>
     <li><a href="#開發規劃-">開發規劃</a></li>
@@ -51,6 +51,42 @@
     <li><a href="#致謝-">致謝</a></li>
   </ol>
 </div>
+
+---
+
+## 安裝 📦
+
+### 全自動安裝（推薦） ⚡
+
+1. **下載安裝程式：**
+   [安裝程式](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/releases/latest)
+   *(安裝程式為開源，可檢視其原始碼)*
+2. **執行安裝程式：**
+
+   * 雙擊 installer.exe 開始安裝。
+   * 若出現提示，請授權系統管理員權限。
+   * 安裝程式會自動偵測 PotPlayer 的 `Extension\Subtitle\Translate` 目錄，若有自訂路徑請確認或手動選擇。
+   * 選擇插件版本（有語境 / 無語境）。
+   * 設定模型、API 位址與 API Key（若介面不需要 API Key，可留空以使用 `nullkey`）。
+   * 安裝程式可選擇註冊解除安裝項目，方便之後移除插件。
+   * 如果安裝程式已寫入預設配置，在你未於 PotPlayer 面板重新調整之前會沿用這些配置；一旦在面板中修改，將始終以面板設定為準。
+
+### 手動安裝 🔧
+
+1. **下載 ZIP 檔案：**
+   從本倉庫下載最新版 ZIP 檔。
+2. **解壓 ZIP 檔：**
+   將內容解壓到臨時資料夾。
+3. **複製檔案：**
+   將 `ChatGPTSubtitleTranslate.as` 和 `ChatGPTSubtitleTranslate.ico` 複製到以下目錄：
+
+   ```
+   C:\Program Files\DAUM\PotPlayer\Extension\Subtitle\Translate
+   ```
+
+   若你的 PotPlayer 安裝於其他路徑，請將 `C:\Program Files\DAUM\PotPlayer` 替換成對應路徑。
+
+<p align="right">(<a href="#readme-top">回到頂部</a>)</p>
 
 ---
 
@@ -119,42 +155,6 @@
 * **AngleScript** – 插件開發腳本語言
 * **ChatGPT API** – 提供語境感知翻譯功能
 * **PotPlayer API** – 與 PotPlayer 無縫整合
-
-<p align="right">(<a href="#readme-top">回到頂部</a>)</p>
-
----
-
-## 安裝 📦
-
-### 全自動安裝（推薦） ⚡
-
-1. **下載安裝程式：**
-   [安裝程式](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/releases/latest)
-   *(安裝程式為開源，可檢視其原始碼)*
-2. **執行安裝程式：**
-
-   * 雙擊 installer.exe 開始安裝。
-   * 若出現提示，請授權系統管理員權限。
-   * 安裝程式會自動偵測 PotPlayer 的 `Extension\Subtitle\Translate` 目錄，若有自訂路徑請確認或手動選擇。
-   * 選擇插件版本（有語境 / 無語境）。
-   * 設定模型、API 位址與 API Key（若介面不需要 API Key，可留空以使用 `nullkey`）。
-   * 安裝程式可選擇註冊解除安裝項目，方便之後移除插件。
-   * 如果安裝程式已寫入預設配置，在你未於 PotPlayer 面板重新調整之前會沿用這些配置；一旦在面板中修改，將始終以面板設定為準。
-
-### 手動安裝 🔧
-
-1. **下載 ZIP 檔案：**
-   從本倉庫下載最新版 ZIP 檔。
-2. **解壓 ZIP 檔：**
-   將內容解壓到臨時資料夾。
-3. **複製檔案：**
-   將 `ChatGPTSubtitleTranslate.as` 和 `ChatGPTSubtitleTranslate.ico` 複製到以下目錄：
-
-   ```
-   C:\Program Files\DAUM\PotPlayer\Extension\Subtitle\Translate
-   ```
-
-   若你的 PotPlayer 安裝於其他路徑，請將 `C:\Program Files\DAUM\PotPlayer` 替換成對應路徑。
 
 <p align="right">(<a href="#readme-top">回到頂部</a>)</p>
 

--- a/docs/readme_zh.md
+++ b/docs/readme_zh.md
@@ -31,9 +31,6 @@
 <div>
   <h2>📑 目录</h2>
   <ol>
-    <li><a href="#关于项目-">关于项目</a></li>
-    <li><a href="#视频教程-">视频教程</a></li>
-    <li><a href="#技术栈-">技术栈</a></li>
     <li>
       <a href="#安装-">安装</a>
       <ol>
@@ -41,6 +38,9 @@
         <li><a href="#手动安装-">手动安装</a></li>
       </ol>
     </li>
+    <li><a href="#关于项目-">关于项目</a></li>
+    <li><a href="#视频教程-">视频教程</a></li>
+    <li><a href="#技术栈-">技术栈</a></li>
     <li><a href="#配置-">配置</a></li>
     <li><a href="#使用方法-">使用方法</a></li>
     <li><a href="#开发计划-">开发计划</a></li>
@@ -50,6 +50,41 @@
     <li><a href="#致谢-">致谢</a></li>
   </ol>
 </div>
+
+---
+
+## 安装 📦
+
+### 全自动安装（推荐） ⚡
+
+1. **下载安装程序：**  
+   [安装程序](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/releases/latest)  
+   *(安装程序是开源的，你可以查看其源码)*
+2. **运行安装程序：**
+   - 双击 installer.exe 启动安装。
+   - 如有提示，请授予管理员权限。
+   - 安装程序会自动检测 PotPlayer 的 `Extension\Subtitle\Translate` 目录，如有自定义路径请确认或手动选择。
+   - 选择插件版本（有上下文 / 无上下文）。
+   - 配置模型、API 地址与 API Key（若接口无需 API Key，可留空以使用 `nullkey`）。
+   - 安装程序可选择注册卸载项，方便后续清理插件。
+   - 如果安装器已经写入默认配置，在你未在 PotPlayer 面板中重新调整之前会继续使用这些配置；一旦在面板中修改，将始终以面板设置为准。
+
+### 手动安装 🔧
+
+1. **下载 ZIP 文件：**  
+   从本仓库下载最新的 ZIP 文件。
+2. **解压 ZIP 文件：**  
+   将内容解压到临时文件夹中。
+3. **复制文件：**  
+   将 `ChatGPTSubtitleTranslate.as` 和 `ChatGPTSubtitleTranslate.ico` 复制到以下目录：
+   
+   ```
+   C:\Program Files\DAUM\PotPlayer\Extension\Subtitle\Translate
+   ```
+   
+   如果你的 PotPlayer 安装在其他位置，请将 `C:\Program Files\DAUM\PotPlayer` 替换为相应路径。
+
+<p align="right">(<a href="#readme-top">返回顶部</a>)</p>
 
 ---
 
@@ -111,41 +146,6 @@
 - **AngleScript** – 用于开发插件的脚本语言  
 - **ChatGPT API** – 提供上下文感知的翻译功能  
 - **PotPlayer API** – 实现与 PotPlayer 的无缝集成
-
-<p align="right">(<a href="#readme-top">返回顶部</a>)</p>
-
----
-
-## 安装 📦
-
-### 全自动安装（推荐） ⚡
-
-1. **下载安装程序：**  
-   [安装程序](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate/releases/latest)  
-   *(安装程序是开源的，你可以查看其源码)*
-2. **运行安装程序：**
-   - 双击 installer.exe 启动安装。
-   - 如有提示，请授予管理员权限。
-   - 安装程序会自动检测 PotPlayer 的 `Extension\Subtitle\Translate` 目录，如有自定义路径请确认或手动选择。
-   - 选择插件版本（有上下文 / 无上下文）。
-   - 配置模型、API 地址与 API Key（若接口无需 API Key，可留空以使用 `nullkey`）。
-   - 安装程序可选择注册卸载项，方便后续清理插件。
-   - 如果安装器已经写入默认配置，在你未在 PotPlayer 面板中重新调整之前会继续使用这些配置；一旦在面板中修改，将始终以面板设置为准。
-
-### 手动安装 🔧
-
-1. **下载 ZIP 文件：**  
-   从本仓库下载最新的 ZIP 文件。
-2. **解压 ZIP 文件：**  
-   将内容解压到临时文件夹中。
-3. **复制文件：**  
-   将 `ChatGPTSubtitleTranslate.as` 和 `ChatGPTSubtitleTranslate.ico` 复制到以下目录：
-   
-   ```
-   C:\Program Files\DAUM\PotPlayer\Extension\Subtitle\Translate
-   ```
-   
-   如果你的 PotPlayer 安装在其他位置，请将 `C:\Program Files\DAUM\PotPlayer` 替换为相应路径。
 
 <p align="right">(<a href="#readme-top">返回顶部</a>)</p>
 


### PR DESCRIPTION
### Motivation
- Make the installation instructions immediately visible by placing the `Installation` section first in all README variants. 
- Improve discoverability for users who only need installation steps and reduce repeated scrolling. 
- Keep English, Simplified Chinese, and Traditional Chinese documentation consistent in structure. 

### Description
- Reordered the Table of Contents and moved the `Installation` content before the project overview in `README.md`, `docs/readme_zh.md`, and `docs/readme_zh-tw.md`.
- Added the `Installation` block (with `Fully Automatic Installation` and `Manual Installation` subsections) at the top of each README and removed the previous duplicate placement lower in the files.
- Updated internal navigation anchors and the "back to top" link placement so the TOC and installation anchors resolve correctly.
- Changes are documentation-only and do not modify code or runtime behavior.

### Testing
- No automated tests were run because the changes are documentation-only.
- Verified updated files `README.md`, `docs/readme_zh.md`, and `docs/readme_zh-tw.md` were modified as intended by inspecting the files locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965501a5b34832c924696b50177a73f)