### PR TITLE
Recompute failure flag after retry in translation scripts

### DIFF
--- a/SubtitleTranslate - ChatGPT - Without Context.as
+++ b/SubtitleTranslate - ChatGPT - Without Context.as
@@ -684,6 +684,8 @@ string Translate(string Text, string &in SrcLang, string &in DstLang) {
                     }
                 }
             }
+            isFailureTranslation = translatedText.length() >= GPT_WC_TRANSLATION_FAILURE_WARNING_PREFIX.length() &&
+                                   translatedText.substr(0, GPT_WC_TRANSLATION_FAILURE_WARNING_PREFIX.length()) == GPT_WC_TRANSLATION_FAILURE_WARNING_PREFIX;
         }
 
         if (!isFailureTranslation && GPT_selected_model.find("gemini") != -1) {

--- a/SubtitleTranslate - ChatGPT.as
+++ b/SubtitleTranslate - ChatGPT.as
@@ -785,6 +785,8 @@ string Translate(string Text, string &in SrcLang, string &in DstLang) {
                 }
             }
         }
+        isFailureTranslation = translation.length() >= GPT_CTX_TRANSLATION_FAILURE_WARNING_PREFIX.length() &&
+                               translation.substr(0, GPT_CTX_TRANSLATION_FAILURE_WARNING_PREFIX.length()) == GPT_CTX_TRANSLATION_FAILURE_WARNING_PREFIX;
     }
 
     if (!isFailureTranslation && GPT_selected_model.find("gemini") != -1) {


### PR DESCRIPTION
### Motivation
- Ensure `isFailureTranslation` reflects the final translation after a retry so downstream post-processing (newline trimming, RTL prefixing, etc.) correctly handles retry-updated content.

### Description
- After the retry branch in `SubtitleTranslate - ChatGPT - Without Context.as`, recompute `isFailureTranslation` from the updated `translatedText` value.
- After the retry branch in `SubtitleTranslate - ChatGPT.as`, recompute `isFailureTranslation` from the updated `translation` value.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968fa0996e4832c9523859c325abc17)