### PR TITLE
Fix undefined escaped message variables in without-context payloads

### DIFF
--- a/SubtitleTranslate - ChatGPT - Without Context.as
+++ b/SubtitleTranslate - ChatGPT - Without Context.as
@@ -366,11 +366,11 @@ string ServerLogin(string User, string Pass) {
     string verifyHeaders = BuildAuthHeaders(Pass);
     string testSystemMsg = "You are a test assistant.";
     string testUserMsg = "Hello";
-    string escapedTestSystemMsg = JsonEscape(testSystemMsg);
-    string escapedTestUserMsg = JsonEscape(testUserMsg);
+    string escapedSystemMsg = JsonEscape(testSystemMsg);
+    string escapedUserMsg = JsonEscape(testUserMsg);
     string testRequestData = "{\"model\":\"" + userModel + "\"," 
-                             "\"messages\":[{\"role\":\"system\",\"content\":\"" + escapedTestSystemMsg + "\"}," 
-                             "{\"role\":\"user\",\"content\":\"" + escapedTestUserMsg + "\"}]}";
+                             "\"messages\":[{\"role\":\"system\",\"content\":\"" + escapedSystemMsg + "\"}," 
+                             "{\"role\":\"user\",\"content\":\"" + escapedUserMsg + "\"}]}";
     string testResponse = HostUrlGetString(apiUrlLocal, GPT_UserAgent, verifyHeaders, testRequestData);
     if (testResponse != "") {
         JsonReader testReader;
@@ -632,8 +632,8 @@ string Translate(string Text, string &in SrcLang, string &in DstLang) {
     string escapedUserMsg = JsonEscape(userMsg);
 
     string requestData = "{\"model\":\"" + GPT_selected_model + "\"," 
-                         "\"messages\":[{\"role\":\"system\",\"content\":\"" + escapedTestSystemMsg + "\"}," 
-                         "{\"role\":\"user\",\"content\":\"" + escapedTestUserMsg + "\"}]}";
+                         "\"messages\":[{\"role\":\"system\",\"content\":\"" + escapedSystemMsg + "\"}," 
+                         "{\"role\":\"user\",\"content\":\"" + escapedUserMsg + "\"}]}";
 
     string headers = BuildAuthHeaders(GPT_api_key);
     int delayInt = ParseInt(GPT_delay_ms);


### PR DESCRIPTION
### Motivation
- Resolve a compile/runtime error caused by `Translate(...)` referencing out-of-scope test variables `escapedTestSystemMsg` and `escapedTestUserMsg` in `SubtitleTranslate - ChatGPT - Without Context.as`.

### Description
- Replace the incorrect references with the in-scope `escapedSystemMsg` and `escapedUserMsg` when building the JSON payload for both the login test and the `Translate` request in `SubtitleTranslate - ChatGPT - Without Context.as`.

### Testing
- Verified with `rg` that `escapedTestSystemMsg` and `escapedTestUserMsg` no longer appear in `SubtitleTranslate - ChatGPT - Without Context.as` and inspected the diff to confirm only the intended variable replacements were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03da6ac3e88321bae2956c5f68a156)